### PR TITLE
Run on smallvoice

### DIFF
--- a/cpp_src/CMakeLists.txt
+++ b/cpp_src/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(AlphaBSc)
 
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_FLAGS "-Wall -O3 -Wextra") #-DNDEBUG
+set(CMAKE_CXX_FLAGS "-Wall -O3 -Wextra -pthread") #-DNDEBUG
 # set(CMAKE_CXX_FLAGS " -O3") #-DNDEBUG
 
 
@@ -17,11 +17,11 @@ include_directories(".libs/libtorch/include")
 
 find_package(Torch REQUIRED)
 
-include_directories(".libs/mariadb_conn_c/include/mariadb") #path to include folder
-include_directories(".libs/mariadb_conn_cpp/include/mariadb") #path to include folder
+include_directories(".libs/mariadb_conn_c/include") #path to include folder
+include_directories(".libs/mariadb_conn_cpp/include") #path to include folder
 include_directories(".libs/gsl/include") #path to include folder
 
-link_directories(./libs/gsl/lib)
+link_directories(./.libs/gsl/lib)
 
 add_library(mariadbcpp STATIC IMPORTED)
 

--- a/cpp_src/CMakeLists.txt
+++ b/cpp_src/CMakeLists.txt
@@ -19,6 +19,9 @@ find_package(Torch REQUIRED)
 
 include_directories(".libs/mariadb_conn_c/include/mariadb") #path to include folder
 include_directories(".libs/mariadb_conn_cpp/include/mariadb") #path to include folder
+include_directories(".libs/gsl/include") #path to include folder
+
+link_directories(./libs/gsl/lib)
 
 add_library(mariadbcpp STATIC IMPORTED)
 

--- a/cpp_src/CMakeLists.txt
+++ b/cpp_src/CMakeLists.txt
@@ -6,19 +6,23 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_FLAGS "-Wall -O3 -Wextra") #-DNDEBUG
 # set(CMAKE_CXX_FLAGS " -O3") #-DNDEBUG
 
-set(LIBTORCH ".libs/libtorch/")
 
-set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${LIBTORCH}")
+set(LIBTORCH ".libs/libtorch/")
+set(MARIADB_C ".libs/mariadb_conn_c")
+set(MARIADB_CPP ".libs/mariadb_conn_cpp")
+
+set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${LIBTORCH};${MARIADB_C};${MARIADB_CPP}")
 
 include_directories(".libs/libtorch/include")
 
 find_package(Torch REQUIRED)
 
-include_directories("/usr/include/mariadb") #path to include folder
+include_directories(".libs/mariadb_conn_c/include/mariadb") #path to include folder
+include_directories(".libs/mariadb_conn_cpp/include/mariadb") #path to include folder
 
 add_library(mariadbcpp STATIC IMPORTED)
 
-set_property(TARGET mariadbcpp PROPERTY IMPORTED_LOCATION "/usr/lib/libmariadbcpp.so") #path to libmariadbcpp.so
+set_property(TARGET mariadbcpp PROPERTY IMPORTED_LOCATION ".libs/mariadb_conn_cpp/lib/mariadb/libmariadbcpp.so") #path to libmariadbcpp.so
 
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")

--- a/readme.md
+++ b/readme.md
@@ -3,29 +3,20 @@
 # Requirements
 
 ## C++
-
-
 Create a folder in `cpp_src` called `.libs`. 
 
 ### Torch 
 Download torch binaries from [here](https://pytorch.org/) (around 2 GB) and extract them into `.libs`.
 
 ### MariaDB
-Install C++ connector from [here](https://mariadb.com/docs/skysql/connect/programming-languages/cpp/install/).
+We need the C++ connector for MariaDB. Obtain both the C++ and C connector [here](https://mariadb.com/downloads/connectors/connectors-data-access/cpp-connector/). Extract the C connector into `.libs/mariadb_conn_c`, and the C++ connector into `.libs/mariadb_conn_cpp`.
 
 ### GSL
-Install the *GNU Scientific Library* (GSL). On ubuntu, this is 
-```
-sudo apt install libgsl-dev
-```
-On Fedora, use 
-```
-sudo dnf install gsl
-```
+Install the *GNU Scientific Library* (GSL). The library must be put in the `.libs/gsl` directory. Follow instructions from [here](https://coral.ise.lehigh.edu/jild13/2016/07/11/hello/).
+
 
 ## Database
-We use a MariaDB database. Using docker, create the image with
-
+We use a MariaDB database. Using docker, create the container with
 
 ```
 docker run --name alpha_db -p 127.0.0.1:3306:3306 -e MARIADB_USER=user  -e MARIADB_PASSWORD=password -e MARIADB_ROOT_PASSWORD=password -d mariadb 
@@ -35,3 +26,4 @@ Then you can access it in a terminal with
 ``` 
 docker exec -it alpha_db mariadb --user root -ppassword
 ```
+


### PR DESCRIPTION
Needed to package all libraries used in the `.libs` folder, as we don't have root privileges on the remote server. 

C++ source now compiles on the server.